### PR TITLE
In convert_date(), round the seconds values for more accuracy

### DIFF
--- a/pyxlsb/__init__.py
+++ b/pyxlsb/__init__.py
@@ -16,10 +16,10 @@ def convert_date(date):
 
   from datetime import datetime, timedelta
   if int(date) == 0:
-    return datetime(1900, 1, 1, 0, 0, 0) + timedelta(seconds=date * 24 * 60 * 60)
+    return datetime(1900, 1, 1, 0, 0, 0) + timedelta(seconds=round(date * 24 * 60 * 60))
   elif int(date) >= 61:
     # According to Lotus 1-2-3, Feb 29th 1900 is a real thing, therefore we have to remove one day after that date
-    return datetime(1899, 12, 31, 0, 0, 0) + timedelta(days=int(date) - 1, seconds=int((date % 1) * 24 * 60 * 60))
+    return datetime(1899, 12, 31, 0, 0, 0) + timedelta(days=int(date) - 1, seconds=round((date % 1) * 24 * 60 * 60))
   else:
     # Feb 29th 1900 will show up as Mar 1st 1900 because Python won't handle that date
-    return datetime(1899, 12, 31, 0, 0, 0) + timedelta(days=int(date), seconds=int((date % 1) * 24 * 60 * 60))
+    return datetime(1899, 12, 31, 0, 0, 0) + timedelta(days=int(date), seconds=round((date % 1) * 24 * 60 * 60))


### PR DESCRIPTION
First off, many thanks for creating this package @willtrnr .  It's greatly appreciated.

This PR should address an issue I found when converting datetime values from the floats in an .xlsb spreadsheet.  The date in question was July 4 2020 at 10:00:00.  In Excel, this is stored as the floating point number 44016.416666666664.  However, when `convert_date()` is used to retrieve the datetime, something unexpected happened:
```
>>> pyxlsb.convert_date(44016.416666666664)
datetime.datetime(2020, 7, 4, 9, 59, 59)  # the time should be 10:00:00, not 09:59:59
```
In `convert_seconds()` the seconds values are cast to integers with `int`.  This truncates the seconds, whereas `round` will I believe return a better, more correct value:
```
>>> (44016.416666666664 % 1) * 24 * 60 * 60
35999.99999979045
>>> int((44016.416666666664 % 1) * 24 * 60 * 60)  # existing code
35999
>>> round((44016.416666666664 % 1) * 24 * 60 * 60)  # new code
36000
```
Hence, this PR changes the `int` to `round` so the nearest seconds value is returned, not the lower one.